### PR TITLE
ci: GitHub Actions を Node.js 24 対応版へアップグレード

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,16 +32,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # https://github.com/actions/checkout/releases/tag/v5.0.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.291.0
-        uses: ruby/setup-ruby@9d13dd6ce2979b207024f719160a99112fb38eea
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.306.0
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        # https://github.com/actions/configure-pages/releases/tag/v6.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -49,7 +51,8 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        # https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   # Deployment job
   deploy:
@@ -61,4 +64,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        # https://github.com/actions/deploy-pages/releases/tag/v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary

- 2026-09-16 の Node.js 20 サポート終了に備え、`.github/workflows/jekyll.yml` の各アクションを Node 24 ランタイム採用版に更新
- これまで `ruby/setup-ruby` のみだった SHA pin を全アクションに統一 (タグ末尾に `# vX.Y.Z` コメント付き)

| Action | Before | After (Node 24) |
|--------|--------|-----------------|
| `actions/checkout` | `@v4` | `v5.0.1` (保守的選択。最新は v6 だが credential 永続化方式が変更されているため見送り) |
| `ruby/setup-ruby` | `v1.291.0` | `v1.306.0` |
| `actions/configure-pages` | `@v5` | `v6.0.0` |
| `actions/upload-pages-artifact` | `@v3` | `v5.0.0` (内部 `upload-artifact@v7`) |
| `actions/deploy-pages` | `@v5` (タグ参照) | `v5.0.0` (SHA pin 化のみ。元から Node 24 対応) |

`upload-pages-artifact@v4.0.0` の破壊的変更で隠しファイル (dotfiles) がアーカイブから除外されるが、`_site/` 配下の dotfile は本ブログサイトでは参照していないため影響なし。

## Test plan

- [ ] PR マージ後、`master` への push をトリガーに `Deploy Jekyll site to Pages` workflow が走る
- [ ] `build` ジョブ全ステップが緑、Node 20 EOL 警告 (`Node.js 20 actions are deprecated`) が消えていること
- [ ] `deploy` ジョブ完了 → サイト URL が出力されること
- [ ] 本番サイトのトップページ・最近のポストが 200 で表示
- [ ] 数式レンダリング (`use_math: true`) が壊れていないこと